### PR TITLE
Change executeUpdate to executeStatement for schemaMigrator

### DIFF
--- a/Classes/Xclass/Schema/SchemaMigrator.php
+++ b/Classes/Xclass/Schema/SchemaMigrator.php
@@ -65,7 +65,7 @@ class SchemaMigrator extends \TYPO3\CMS\Core\Database\Schema\SchemaMigrator
 
             foreach ((array)$perTableStatements as $statement) {
                 try {
-                    $connection->executeUpdate($statement);
+                    $connection->executeStatement($statement);
                     $result[$statement] = '';
                 } catch (DBALException $e) {
                     $result[$statement] = $e->getPrevious()->getMessage();


### PR DESCRIPTION
The executeUpdate Method does not exist in TYPO3 13