### PR TITLE
[BUGFIX] Declare extending SchemaMigrator readonly

### DIFF
--- a/Classes/Xclass/Schema/SchemaMigrator.php
+++ b/Classes/Xclass/Schema/SchemaMigrator.php
@@ -32,7 +32,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  *
  * @internal
  */
-class SchemaMigrator extends \TYPO3\CMS\Core\Database\Schema\SchemaMigrator
+readonly class SchemaMigrator extends \TYPO3\CMS\Core\Database\Schema\SchemaMigrator
 {
     /**
      * Import static data (UPDATE and INSERT statements)


### PR DESCRIPTION
The parent class is readonly, so an extending class could not be non-readonly.

Fixes #6